### PR TITLE
수박 게임 만들기 7주차

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -285,8 +285,22 @@ MonoBehaviour:
   lastDongle: {fileID: 0}
   donglePrefab: {fileID: 2121322809823622469, guid: a3498a10a80f22a499dd608623e8d43f, type: 3}
   dongleGroup: {fileID: 502833239}
+  donglePool:
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
   effectPrefab: {fileID: 3740424817230927496, guid: 7c152f103948a0a45b2907c01271c8ad, type: 3}
   effectGroup: {fileID: 868690106}
+  effectPool:
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  poolSize: 5
+  poolCursor: 0
   bgmPlayer: {fileID: 811142303}
   sfxPlayer:
   - {fileID: 1027092105}
@@ -541,7 +555,7 @@ Transform:
   m_GameObject: {fileID: 502833238}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: 8, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/Assets/Scripts/Dongle.cs
+++ b/Assets/Scripts/Dongle.cs
@@ -25,13 +25,30 @@ public class Dongle : MonoBehaviour
         spriteRenderer = GetComponent<SpriteRenderer>();
     }
 
-    private void OnEnable()
+    void OnEnable()
     {
         anim.SetInteger("Level", level);
     }
-    void Start()
+    void OnDisable()
     {
+        // 동글 속성 초기화
+        level = 0;
         isDrag = false;
+        isMerge = false;
+        isAttach = false;
+
+        // 동글 트랜스폼 초기화
+        transform.localPosition = Vector3.zero;
+        transform.localRotation = Quaternion.identity; // vector3.zero 와 똑같은 값
+        transform.localScale = Vector3.zero;
+
+        // 동글 물리 초기화
+        rigid.simulated = false;
+        rigid.velocity = Vector2.zero;
+        rigid.angularVelocity = 0;
+        circle.enabled = true;
+
+
     }
     void Update()
     {
@@ -143,7 +160,7 @@ public class Dongle : MonoBehaviour
     {
         isMerge = true;
 
-        rigid.velocity = Vector2.zero; // vector2인 이유 : rigidbodyt2D 이기 때문에
+        rigid.velocity = Vector2.zero; // vector2인 이유 : rigidbody2D 이기 때문에
         rigid.angularVelocity = 0; // + 값이면 시계방향, - 값이면 반시계방향
 
         StartCoroutine(LevelUpRoutine());


### PR DESCRIPTION
# 개요
- 골드메탈 물리 퍼즐게임 -쉽게 구현해보는 오브젝트풀링[유니티 기초 강좌 B60] 강의를 듣고 따라 만들었습니다.
- 
# 배운 점
- 오브젝트 풀링 : 자주 사용하는 오브젝트를 미리 생성해 놓고 사용할 때마다 생성, 삭제하는 것이 아닌 오브젝트풀에게서 빌리고 돌려줌으로써 단순하게 오브젝트를 활성화, 비활성화 하는 개념이다.
- 리스트 변수로 오브젝트 풀을 선언해준다
- 오브젝트 풀의 사이즈 변수를 만들고 그 윗 줄에 [Range(n, m)]을 써주면 인스펙터 창에 바가 생긴다.
- 재사용을 하기 때문에 사용할 때마다 초기 상태로 초기화를 해주어야 함

# 느낀점
- 재활용되는 동글들이 화면 정중앙에 생성되어서 스크립트에 오류가 있나.. 찾아봤지만 오류가 없었다. 그래서 Hierarchy내의 Dongle Group의 Position을 8로 설정하여 해결하였다.  알맞게 해결했는지는 모르겠다ㅠ
- 오브젝트를 많이 생성할 필요가 있는 경우엔 오브젝트 풀링을 사용하는 것이 좋다고 한다.  제작하고자 하는 게임의 장르에 따라 오브젝트 풀링의 사용 유무가 갈리지 않을까 라는 생각이 든다. 
- 다소 복잡한 게임을 만들 때, 오브젝트 풀의 객체 재사용을 위해 초기화를 해주어야 하는 부분에서 번거로움이 있을 것 같다.
- 스크립트를 짤 때 실수 하나 하면 의도대로 돌아가지 않는 무한 지옥에 빠질 것 같다.
- 게임 장르에 따른 오브젝트 풀링을 효과적으로 적용하는 방법에 대해 생각해봤지만, 그냥 많이 보고, 써보면서 익혀보도록 하자..

# 참고 자료
- 골드메탈 물리 퍼즐게임 -쉽게 구현해보는 오브젝트풀링[유니티 기초 강좌 B60]
https://www.youtube.com/watch?v=uFAYFoaEwhk&t=507s
